### PR TITLE
Block comment unused nctoolbox ugrid code.

### DIFF
--- a/extern/nctoolbox/cdm/ncugrid.m
+++ b/extern/nctoolbox/cdm/ncugrid.m
@@ -3,6 +3,7 @@
 %            >> dataset = ncugrid(uri);
 %
 % NCTOOLBOX (http://code.google.com/p/nctoolbox)
+%{
 classdef ncugrid < handle
     
     properties (SetAccess = private)
@@ -693,3 +694,4 @@ classdef ncugrid < handle
     end % end methods
     
 end % end class
+%}

--- a/extern/nctoolbox/cdm/ncuvariable.m
+++ b/extern/nctoolbox/cdm/ncuvariable.m
@@ -2,6 +2,7 @@
 % Trying out sort of an interface approach, I think I like it - Acrosby
 %
 % NCTOOLBOX (http://code.google.com/p/nctoolbox)
+%{
 classdef ncuvariable < handle
     
     properties (SetAccess = private)
@@ -239,3 +240,4 @@ classdef ncuvariable < handle
     end % methods end
     
 end % class end
+%}


### PR DESCRIPTION
Block comment unused code in ncugrid.m and ncuvariable.m so that imports dependent on incomplete nctoolbox implementation of NetCDF-UGRID-Java are not scanned by Matlab Application Compiler's code generation readiness checks. This code is not required for adclite as references to it in nctoolbox in ncgeodataset.m and ncgeovariable.m were already commented out in this (and even the current) version of nctoolbox.