### PR TITLE
Load Model from Web

### DIFF
--- a/LoadRsmModel.m
+++ b/LoadRsmModel.m
@@ -1,20 +1,27 @@
-function [Model,TheGrid]=LoadRsmModel(HOME,ModelName,GridName)
+function [Model,TheGrid]=LoadRsmModel(ADCLHOME,ModelDir,ModelFile,ModelURL,ModelName,GridName)
 
 global Debug
 if Debug,fprintf('SSViz++ Function = %s\n',ThisFunctionName);end
 
+MODELHOME=fullfile(ADCLHOME, ModelDir);
+MODELPATH=fullfile(ADCLHOME, ModelFile)
 
-temp=sprintf('%s/Model/%s.mat',HOME,ModelName);
+if ~exist(MODELHOME,'dir')
+    ModelTar=websave(MODELPATH, ModelURL)
+    untar(ModelTar, ADCLHOME)
+end
+
+temp=sprintf('%s/%s/%s.mat', ADCLHOME, ModelDir, ModelName);
 temp=load(temp);
-com=sprintf('Model=temp.%s;',ModelName);
+com=sprintf('Model=temp.%s;', ModelName);
 eval(com);
 
-temp=load(sprintf('%s/Model/%s.mat',HOME,GridName));
-com=sprintf('TheGrid=temp.;',ModelName);
+temp=load(sprintf('%s/%s/%s.mat', ADCLHOME, ModelDir, GridName));
+com=sprintf('TheGrid=temp.;', ModelName);
 TheGrid=temp.fgs;
 
 nm='large_group_of_indices_for_R';
-temp=load(sprintf('%s/Model/%s.mat',HOME,nm));
+temp=load(sprintf('%s/%s/%s.mat', ADCLHOME, ModelDir, nm));
 com=sprintf('idx=temp.%s;',nm);
 eval(com)
 TheGrid.idx=idx';

--- a/LoadRsmModel.m
+++ b/LoadRsmModel.m
@@ -7,8 +7,15 @@ MODELHOME=fullfile(ADCLHOME, ModelDir);
 MODELPATH=fullfile(ADCLHOME, ModelFile)
 
 if ~exist(MODELHOME,'dir')
+    fprintf('\nSSViz++ Downloading model.\n')
     ModelTar=websave(MODELPATH, ModelURL)
+    fprintf('\nSSViz++ Model downloaded.\n')
+    fprintf('\nSSViz++ Expanding model data.\n')
     untar(ModelTar, ADCLHOME)
+    fprintf('\nSSViz++ Model data expanded.\n')
+else
+    fprintf('\nSSViz++ Model aldready exists.\n')
+
 end
 
 temp=sprintf('%s/%s/%s.mat', ADCLHOME, ModelDir, ModelName);

--- a/StormSurgeViz.m
+++ b/StormSurgeViz.m
@@ -127,7 +127,7 @@ Url.Units=ADCLOPTS.Units;
 global Model
 global TheGrids TheGrid
 fprintf('SSViz++ Loading RSM ... \n')
-[Model,TheGrid]=LoadRsmModel(ADCLOPTS.HOME,ADCLOPTS.ModelName,ADCLOPTS.GridName);
+[Model,TheGrid]=LoadRsmModel(ADCLOPTS.ADCLHOME,ADCLOPTS.ModelDir,ADCLOPTS.ModelFile,ADCLOPTS.ModelURL,ADCLOPTS.ModelName,ADCLOPTS.GridName);
 
 TheGrids{1}=TheGrid;
 

--- a/StormSurgeViz_Init.m
+++ b/StormSurgeViz_Init.m
@@ -106,11 +106,13 @@ end
 
 if isdeployed
     if ~exist(ADCLHOME, 'dir')
+        fprintf(sprintf('\nSSViz++ Creating ADCLHOME at %s.\n', ADCLHOME))
         mkdir(ADCLHOME)
     end
 end
 
 if ~exist(TempDataLocation,'dir')
+    fprintf(sprintf('\nSSViz++ Creating TempData at %s.\n', TempDataLocation))
     mkdir(TempDataLocation)
 end
 

--- a/StormSurgeViz_Init.m
+++ b/StormSurgeViz_Init.m
@@ -3,6 +3,16 @@ function ADCLOPTS=StormSurgeViz_Init(varargin)
 PWD=pwd;
 
 HOME=fileparts(which(mfilename));
+
+USERHOME=HOME;
+if isdeployed
+    if ispc
+        USERHOME=getenv('USERPROFILE');
+    else
+        USERHOME=getenv('HOME');
+    end
+end
+
 addpath([HOME '/extern'])
 
 if isempty(which('detbndy'))
@@ -24,9 +34,24 @@ set(0,'DefaultAxesTickDir','out')
 set(0,'DefaultFigureRenderer','zbuffer');
 
 LocalDirectory='./';
-TempDataLocation=[PWD '/TempData']; 
+AdclDirectory='.adclite';
+ADCLHOME=HOME;
+if isdeployed
+    ADCLHOME=fullfile(USERHOME, AdclDirectory);
+end
+TempDataDirectory='/TempData';
+TempDataLocation=[PWD TempDataDirectory]; 
+if isdeployed
+    TempDataLocation=fullfile(ADCLHOME, TempDataDirectory);
+end
 DateStringFormatInput='yyyy-mm-dd HH:MM:SS';
 DateStringFormatOutput='ddd, dd mmm, HH:MM PM';
+ModelName='pre_00_CV_DB_two_prime_HS';
+GridName='nc_inundation_v9.81_adjVAB_MSL';
+ModelDir='Model';
+ModelFile='Model.tar';
+ModelURL='http://people.renci.org/~bblanton/data/Model.tar';
+
 
 % name of Java Topology Suite file
 jts='jts-1.9.jar';
@@ -79,6 +104,12 @@ if isempty(which('shapewrite'))
     ADCLOPTS.CanOutputShapeFiles=false;
 end
 
+if isdeployed
+    if ~exist(ADCLHOME, 'dir')
+        mkdir(ADCLHOME)
+    end
+end
+
 if ~exist(TempDataLocation,'dir')
     mkdir(TempDataLocation)
 end
@@ -108,10 +139,15 @@ global Debug
 Debug=ADCLOPTS.Debug;
 
 ADCLOPTS.HOME=HOME;
-ADCLOPTS.LocalDirectory='./';
-ADCLOPTS.TempDataLocation=[PWD '/TempData']; 
-ADCLOPTS.DateStringFormatInput='yyyy-mm-dd HH:MM:SS';
-ADCLOPTS.DateStringFormatOutput='ddd, dd mmm, HH:MM PM';
-ADCLOPTS.ModelName='pre_00_CV_DB_two_prime_HS';
-ADCLOPTS.GridName='nc_inundation_v9.81_adjVAB_MSL';
+ADCLOPTS.USERHOME=USERHOME;
+ADCLOPTS.ADCLHOME=ADCLHOME;
+ADCLOPTS.LocalDirectory=LocalDirectory;
+ADCLOPTS.TempDataLocation=TempDataLocation; 
+ADCLOPTS.DateStringFormatInput=DateStringFormatInput;
+ADCLOPTS.DateStringFormatOutput=DateStringFormatOutput;
+ADCLOPTS.ModelName=ModelName;
+ADCLOPTS.GridName=GridName;
+ADCLOPTS.ModelDir=ModelDir;
+ADCLOPTS.ModelFile=ModelFile;
+ADCLOPTS.ModelURL=ModelURL;
 


### PR DESCRIPTION
To reduce size of installer executable to fit within Win32 installer constraints, download model from web  and untar. Create Model and TempData directories in $HOME/.adclite (%USERPROFILE%/.adclite for Win64 app) for deployed application only. Tested for WIn 7 and Yosemite.